### PR TITLE
Version 1.13 that fixes HC patch

### DIFF
--- a/LoCA.lua
+++ b/LoCA.lua
@@ -150,7 +150,12 @@ function addon:OnEvent(event, ...)
     addon:OnAuraEvent(...)
   elseif event == "LOSS_OF_CONTROL_ADDED" then
     if addon.db.profile.debuffs.mode == "retail" then
-      local eventIndex = ...
+      -- There exists 2 versions paylods for LOSS_OF_CONTROL_ADDED:
+      -- - either eventIndex only
+      -- - or unitTarget first, then eventIndex
+      -- We use a simple hack to support both flavors at the same time
+      local eventIndexOrUnit, eventIndexOrNothing = ...
+      local eventIndex = eventIndexOrNothing or eventIndexOrUnit -- The magic is here
       local data = C_LossOfControl.GetActiveLossOfControlData(eventIndex)
       debuffs:OnLossOfControlEvent(data, eventIndex)
     end

--- a/LoCA_Vanilla.toc
+++ b/LoCA_Vanilla.toc
@@ -1,0 +1,12 @@
+## Interface: 11404
+## Title: Loss of Control Alerter
+## Notes: Shows alerts on loss of control debuffs
+## Version: 1.13
+## Author: Rdmx
+## DefaultState: Enabled
+## SavedVariables: LoCADB
+
+embeds.xml
+
+LoCA.lua
+Modules\Debuffs.lua

--- a/LoCA_Wrath.toc
+++ b/LoCA_Wrath.toc
@@ -1,7 +1,7 @@
-## Interface: 30400
+## Interface: 30402
 ## Title: Loss of Control Alerter
 ## Notes: Shows alerts on loss of control debuffs
-## Version: 1.12
+## Version: 1.13
 ## Author: Rdmx
 ## DefaultState: Enabled
 ## SavedVariables: LoCADB


### PR DESCRIPTION
LOSS_OF_CONTROL_ADDED has two flavors:
- either `eventIndex` only
- or `unitTarget` first, then `eventIndex`
This PR makes sure the addon supports both versions.

This PR also splits TOC file between Vanilla and Wrath.